### PR TITLE
Bug fix: Parse correctly request for export job status.

### DIFF
--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -5120,6 +5120,17 @@ class MarketoClient:
             raise MarketoException(result['errors'][0])
         return result['result']
 
+    def _get_export_jobs_status(self, entity, job_id):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'get', self.host + '/bulk/v1/{}/export/{}/status.json'.format(entity, job_id), args)
+        if not result['success']:
+            raise MarketoException(result['errors'][0])
+        return result['result']
+
     def _export_job_state_machine(self, entity, state, job_id):
         assert entity is not None, 'Invalid argument: required fields is none.'
         assert entity is not None, 'Invalid argument: required fields is none.'
@@ -5145,10 +5156,10 @@ class MarketoClient:
         return self._export_job_state_machine('activities', 'file', *args, **kargs)
 
     def get_leads_export_job_status(self, *args, **kargs):
-        return self._export_job_state_machine('leads', 'status', *args, **kargs)
+        return self._get_export_jobs_status('leads', *args, **kargs)
 
     def get_activities_export_job_status(self, *args, **kargs):
-        return self._export_job_state_machine('activities', 'status', *args, **kargs)
+        return self._get_export_jobs_status('activities', *args, **kargs)
 
     def cancel_leads_export_job(self, *args, **kargs):
         return self._export_job_state_machine('leads', 'cancel', *args, **kargs)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ Originally developed by asamat with contributions from sandipsinha and osamakhn
 
 setup(
     name='marketorestpython',
-    version= '0.3.14',
+    version= '0.3.15',
     url='https://github.com/jepcastelein/marketo-rest-python',
     author='Jep Castelein',
     author_email='jep@castelein.net',


### PR DESCRIPTION
Fix bug of parsing response to request on export job status. Currently,
```
mc.execute(method='get_leads_export_job_status', job_id="XXX")
```
Is throwing
```
File "/marketo-rest-python/marketorestpython/client.py", line 5137, in _export_job_state_machine
if not result['success']:
TypeError: 'Response' object is not subscriptable
```
This PR solves the issue. Tested.