### PR TITLE
Describe2 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,13 @@ API Ref: http://developers.marketo.com/documentation/rest/describe/
 lead = mc.execute(method='describe')
 ```
 
+Describe2
+--------
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/describeUsingGET_6
+```python
+lead = mc.execute(method='describe2')
+```
+
 Get Activity Types
 ------------------
 API Ref: http://developers.marketo.com/documentation/rest/get-activity-types/

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -88,6 +88,7 @@ class MarketoClient:
                     'get_import_failure_file': self.get_import_failure_file,
                     'get_import_warning_file': self.get_import_warning_file,
                     'describe': self.describe,
+                    'describe2': self.describe2,
                     'get_activity_types': self.get_activity_types,
                     'get_paging_token': self.get_paging_token,
                     'get_lead_activities': self.get_lead_activities,

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -1044,6 +1044,17 @@ class MarketoClient:
             raise Exception("Empty Response")
         return result['result']
 
+    def describe2(self):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'get', self.host + "/rest/v1/leads/describe2.json", args)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
     # --------- ACTIVITIES ---------
 
     def get_activity_types(self):


### PR DESCRIPTION
- Added a new method to access the describe2 endpoint on lead/people objects, giving users access to the searchable fields in Marketo for easier to use ETL functions designed to mirror client Marketo DB
- Readme updated, however, the link to the API ref is under the new Docs website and thus doesn't match the url formatting of the other API refs