### PR TITLE
Add Custom Object Type support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1872,7 +1872,6 @@ API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-databas
     resultType = mc.execute(method='create_update_custom_object_type', action='createOnly', apiName='transactions', action='createOnly', displayName='Transactions' description='Transactions custom object for the transactions')
 ```
 
-
 Delete Custom Object Type
 -------------------------
 API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/deleteCustomObjectsUsingPOST
@@ -1891,17 +1890,17 @@ Discard Custom Object Type Draft
 --------------------------------
 API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/discardCustomObjectTypeUsingPOST
 ```python
-    fields = [{"displayName": "Customer ID", "description": "Customer ID", "name": "cid", "dataType": "integer", "relatedTo": '{"name": "customer", "field": "cid"}'},
-    {"displayName": "Transaction ID", "description": "Transaction ID", "name": "txid", "dataType": "integer", "isDedupeField", True},
-    {"displayName": "Total", "description": "Transaction total", "name": "total", "dataType": "float"}]
-    result = mc.execute(method='discard_custom_object_type', apiName='transactions', fields=fields)
+    result = mc.execute(method='discard_custom_object_type', apiName='transactions')
 ```
 
 Add Custom Object Type Fields
 -----------------------------
 https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/addCustomObjectTypeFieldsUsingPOST
 ```python
-    result = mc.execute(method='add_field_custom_object_type', apiName='transactions', data)
+    fields = [{"displayName": "Customer ID", "description": "Customer ID", "name": "cid", "dataType": "integer", "relatedTo": '{"name": "customer", "field": "cid"}'},
+    {"displayName": "Transaction ID", "description": "Transaction ID", "name": "txid", "dataType": "integer", "isDedupeField", True},
+    {"displayName": "Total", "description": "Transaction total", "name": "total", "dataType": "float"}]
+    result = mc.execute(method='add_field_custom_object_type', apiName='transactions',fields=fields)
 ```
 
 
@@ -1934,6 +1933,7 @@ https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoin
 Get Custom Object Dependent Assets
 ----------------------------------
 https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/getCustomObjectTypeDependentAssetsUsingGET
+
 
 Custom Objects
 ==============

--- a/README.md
+++ b/README.md
@@ -1865,7 +1865,7 @@ except KeyError:
 Custom Object Types
 ===================
 
-Create or Update Custom Object Type
+Create/Update Custom Object Type
 -----------------------------------
 API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/syncCustomObjectTypeUsingPOST
 ```python
@@ -1895,7 +1895,7 @@ API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-databas
 
 Add Custom Object Type Fields
 -----------------------------
-https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/addCustomObjectTypeFieldsUsingPOST
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/addCustomObjectTypeFieldsUsingPOST
 ```python
     fields = [{"displayName": "Customer ID", "description": "Customer ID", "name": "cid", "dataType": "integer", "relatedTo": '{"name": "customer", "field": "cid"}'},
     {"displayName": "Transaction ID", "description": "Transaction ID", "name": "txid", "dataType": "integer", "isDedupeField", True},
@@ -1903,16 +1903,21 @@ https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoin
     result = mc.execute(method='add_field_custom_object_type', apiName='transactions',fields=fields)
 ```
 
-
-** Not currently implemented **
-
 List Custom Object Types
 ------------------------
-https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/listCustomObjectTypesUsingGET
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/listCustomObjectTypesUsingGET
+```python
+    coTypes = mc.execute(method='get_list_of_custom_object_types')
+```
 
 Describe Custom Object Type
 ---------------------------
-https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/describeCustomObjectTypeUsingGET
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/describeCustomObjectTypeUsingGET
+```python
+    description = mc.execute(method='describe_custom_object_type')
+```
+
+** Not currently implemented **
 
 Delete Custom Object Type Fields
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -1862,6 +1862,78 @@ except KeyError:
     tag = False
 ```
 
+Custom Object Types
+===================
+
+Create or Update Custom Object Type
+-----------------------------------
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/syncCustomObjectTypeUsingPOST
+```python
+    resultType = mc.execute(method='create_update_custom_object_type', action='createOnly', apiName='transactions', action='createOnly', displayName='Transactions' description='Transactions custom object for the transactions')
+```
+
+
+Delete Custom Object Type
+-------------------------
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/deleteCustomObjectsUsingPOST
+```python
+    result = mc.execute(method='delete_custom_object_type', apiName='transactions')
+```
+
+Approve Custom Object Type
+--------------------------
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/approveCustomObjectTypeUsingPOST
+```python
+    result = mc.execute(method='approve_custom_object_type', apiName='transactions')
+```
+
+Discard Custom Object Type Draft
+--------------------------------
+API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/discardCustomObjectTypeUsingPOST
+```python
+    fields = [{"displayName": "Customer ID", "description": "Customer ID", "name": "cid", "dataType": "integer", "relatedTo": '{"name": "customer", "field": "cid"}'},
+    {"displayName": "Transaction ID", "description": "Transaction ID", "name": "txid", "dataType": "integer", "isDedupeField", True},
+    {"displayName": "Total", "description": "Transaction total", "name": "total", "dataType": "float"}]
+    result = mc.execute(method='discard_custom_object_type', apiName='transactions', fields=fields)
+```
+
+Add Custom Object Type Fields
+-----------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/addCustomObjectTypeFieldsUsingPOST
+```python
+    result = mc.execute(method='add_field_custom_object_type', apiName='transactions', data)
+```
+
+
+** Not currently implemented **
+
+List Custom Object Types
+------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/listCustomObjectTypesUsingGET
+
+Describe Custom Object Type
+---------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/describeCustomObjectTypeUsingGET
+
+Delete Custom Object Type Fields
+--------------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/deleteCustomObjectTypeFieldsUsingPOST
+
+Update Custom Object Type Field
+-------------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/updateCustomObjectTypeFieldUsingPOST
+
+Get Custom Object Type Field Data Types
+---------------------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/getCustomObjectTypeFieldDataTypesUsingGET
+
+Get Custom Object Linkable Objects
+----------------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/getCustomObjectTypeLinkableObjectsUsingGET
+
+Get Custom Object Dependent Assets
+----------------------------------
+https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/getCustomObjectTypeDependentAssetsUsingGET
 
 Custom Objects
 ==============

--- a/README.md
+++ b/README.md
@@ -1897,7 +1897,7 @@ Add Custom Object Type Fields
 -----------------------------
 API Ref: https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/addCustomObjectTypeFieldsUsingPOST
 ```python
-    fields = [{"displayName": "Customer ID", "description": "Customer ID", "name": "cid", "dataType": "integer", "relatedTo": '{"name": "customer", "field": "cid"}'},
+    fields = [{"displayName": "Email", "description": "Email", "name": "email", "dataType": "link", "relatedTo": {"name": "lead", "field": "email"}},
     {"displayName": "Transaction ID", "description": "Transaction ID", "name": "txid", "dataType": "integer", "isDedupeField", True},
     {"displayName": "Total", "description": "Transaction total", "name": "total", "dataType": "float"}]
     result = mc.execute(method='add_field_custom_object_type', apiName='transactions',fields=fields)

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -4475,7 +4475,7 @@ class MarketoClient:
 
     # --------- CUSTOM OBJECT TYPES ---------
 
-    def create_update_custom_object_type(self, apiName, action='createOrUpdate', displayName=None, pluralName=None,
+    def create_update_custom_object_type(self, apiName, action='createOrUpdate', displayName, pluralName=None,
             description=None, showInLeadDetail=None):
         self.authenticate()      
         args = {
@@ -4483,10 +4483,9 @@ class MarketoClient:
         }
         data = {
             'action': action,
-            'apiName': apiName
+            'apiName': apiName,
+            'displayName': displayName
         }
-        if displayName is not None:
-            data['displayName'] = displayName
         if pluralName is not None:
             data['pluralName'] = pluralName
         if description is not None:
@@ -4516,7 +4515,7 @@ class MarketoClient:
             'access_token': self.token
         }
         result = self._api_call(
-            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/approve.json", args, data)
+            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/approve.json", args)
         if result is None:
             raise Exception("Empty Response")
         return result['result']
@@ -4527,7 +4526,7 @@ class MarketoClient:
             'access_token': self.token
         }
         result = self._api_call(
-            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/discardDraft.json", args, data)
+            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/discardDraft.json", args)
         if result is None:
             raise Exception("Empty Response")
         return result['result']

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -235,6 +235,11 @@ class MarketoClient:
                     'get_channel_by_name': self.get_channel_by_name,
                     'get_tags': self.get_tags,
                     'get_tag_by_name': self.get_tag_by_name,
+                    'create_update_custom_object_type': self.create_update_custom_object_type,
+                    'delete_custom_object_type': self.delete_custom_object_type,
+                    'approve_custom_object_type': self.approve_custom_object_type,                    
+                    'discard_custom_object_type': self.discard_custom_object_type,
+                    'add_field_custom_object_type': self.add_field_custom_object_type,
                     'get_list_of_custom_objects': self.get_list_of_custom_objects,
                     'describe_custom_object': self.describe_custom_object,
                     'create_update_custom_objects': self.create_update_custom_objects,
@@ -4466,6 +4471,79 @@ class MarketoClient:
             raise Exception("Empty Response")
         return result['result']
 
+    # --------- CUSTOM OBJECT TYPES ---------
+
+    def create_update_custom_object_type(self, apiName, action='createOrUpdate', displayName=None, pluralName=None,
+            description=None, showInLeadDetail=None):
+        self.authenticate()      
+        args = {
+            'access_token': self.token
+        }
+        data = {
+            'action': action,
+            'apiName': apiName
+        }
+        if displayName is not None:
+            data['displayName'] = displayName
+        if pluralName is not None:
+            data['pluralName'] = pluralName
+        if description is not None:
+            data['description'] = description
+        if showInLeadDetail is not None:
+            data['showInLeadDetail'] = showInLeadDetail
+        result = self._api_call(
+            'post', self.host + "/rest/v1/customobjects/schema.json", args, data)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
+    def delete_custom_object_type(self, apiName):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'post', self.host + "/rest/v1/customobjects/schema/"+ apiName +"/delete.json", args)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
+    def approve_custom_object_type(self, apiName):
+        self.authenticate()      
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'post', self.host + "/rest/v1/customobjects/schema/"+ apiName +"/approve.json", args, data)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
+    def discard_custom_object_type(self, apiName):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/discardDraft.json", args, data)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
+    def add_field_custom_object_type(self, apiName, fields):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        data = {
+            'input': fields
+        }
+        result = self._api_call(
+            'post', self.host + "/rest/v1/customobjects/schema/" + str(apiName) +"/addField.json", args, data)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+                   
     # --------- CUSTOM OBJECTS ---------
 
     def get_list_of_custom_objects(self, names=None):

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -239,6 +239,8 @@ class MarketoClient:
                     'delete_custom_object_type': self.delete_custom_object_type,
                     'approve_custom_object_type': self.approve_custom_object_type,                    
                     'discard_custom_object_type': self.discard_custom_object_type,
+                    'get_list_of_custom_object_types': self.get_list_of_custom_object_types,
+                    'describe_custom_object_type': self.describe_custom_object_type,
                     'add_field_custom_object_type': self.add_field_custom_object_type,
                     'get_list_of_custom_objects': self.get_list_of_custom_objects,
                     'describe_custom_object': self.describe_custom_object,
@@ -4539,11 +4541,33 @@ class MarketoClient:
             'input': fields
         }
         result = self._api_call(
-            'post', self.host + "/rest/v1/customobjects/schema/" + str(apiName) +"/addField.json", args, data)
+            'post', self.host + "/rest/v1/customobjects/schema/" + str(apiName) + "/addField.json", args, data)
         if result is None:
             raise Exception("Empty Response")
         return result['result']
-                   
+
+    def get_list_of_custom_object_types(self):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'get', self.host + "/rest/v1/customobjects/schema.json", args)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
+    def describe_custom_object_type(self, apiName):
+        self.authenticate()
+        args = {
+            'access_token': self.token
+        }
+        result = self._api_call(
+            'get', self.host + "/rest/v1/customobjects/schema/" + str(apiName) + "/describe.json", args)
+        if result is None:
+            raise Exception("Empty Response")
+        return result['result']
+
     # --------- CUSTOM OBJECTS ---------
 
     def get_list_of_custom_objects(self, names=None):

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -4503,7 +4503,7 @@ class MarketoClient:
             'access_token': self.token
         }
         result = self._api_call(
-            'post', self.host + "/rest/v1/customobjects/schema/"+ apiName +"/delete.json", args)
+            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/delete.json", args)
         if result is None:
             raise Exception("Empty Response")
         return result['result']
@@ -4514,7 +4514,7 @@ class MarketoClient:
             'access_token': self.token
         }
         result = self._api_call(
-            'post', self.host + "/rest/v1/customobjects/schema/"+ apiName +"/approve.json", args, data)
+            'post', self.host + "/rest/v1/customobjects/schema/"+ str(apiName) +"/approve.json", args, data)
         if result is None:
             raise Exception("Empty Response")
         return result['result']


### PR DESCRIPTION
This adds 5 of the 12 endpoints for custom object types.

These are:

* create/update
* delete
* approve
* discard draft
* add custom object type fields

The URLs for the API Ref: are accurate, the old URLs that are used for the rest of the methods that already exist in this file are redirected. Maybe time to update those?

I'm calling the first one:

Create or Update Custom Object Type

To match the rest of the stuff in this library, and the name of the function is also named like this. However, in the documetation on the Marketo site it's actually called Sync Custom Object Type. (https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Custom_Objects/syncCustomObjectTypeUsingPOST) 

I notice some of the older documentation is similar and follows this naming conventions, i.e. Create/Update Leads in the documentation goes to a method called create_update_leads which is actually called Sync Leads in the documentation. I tried to follow this library as much as possible with these, but if you were going to do a major version/interface change and rename them to match the documentation, that would be cool. Or not, cos big deal, I'm just OCD with naming in these cases and want things to match.

There are 7 remaining methods in this group, we haven't needed them yet so I haven't implemented them and I don't have time right now. I created a list of the missing ones in the documentation. If we implement more on the project we are on, I will push them as well.

Let me know if this PR is satisfactory as is, if not let me know why and I'll address.

Also if you ever get tired of maintaining this, I'm happy to take it over, either here or in my personal account.

Have a nice day!



