### PR TITLE
https://github.com/jepcastelein/marketo-rest-python/issues/63

### DIFF
--- a/marketorestpython/helper/http_lib.py
+++ b/marketorestpython/helper/http_lib.py
@@ -16,8 +16,7 @@ retryable_error_codes = {
     '1014': 'Failed to create Object',
     '1016': 'Too many imports',
     '1019': 'Import in progress',
-    '1022': 'Object in use',
-    '1029': 'Too many jobs in queue'
+    '1022': 'Object in use'
 }
 
 


### PR DESCRIPTION
Remove the error 1029 as recoverable. This error code should be treated as fail fast

