### PR TITLE
Add support for passing timeout parameter to requests calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ client_id = "" # enter Client ID from Admin > LaunchPoint > View Details
 client_secret= "" # enter Client ID and Secret from Admin > LaunchPoint > View Details
 api_limit=None
 max_retry_time=None
-mc = MarketoClient(munchkin_id, client_id, client_secret, api_limit, max_retry_time)
+requests_timeout=(3.0, 10.0)
+mc = MarketoClient(munchkin_id, client_id, client_secret, api_limit, max_retry_time, requests_timeout=requests_timeout)
 
 # 'api_limit' and 'max_retry_time' are optional;
 # 'api_limit' limits the number of Marketo API calls made by this instance of MarketoClient
 # 'max_retry_time' defaults to 300 and sets the time in seconds to retry failed API calls that 
 #   are retryable; if it still fails after the configured time period, it will throw a 
 #   MarketoException
+# 'requests_timeout' can be an int, float, or tuple of ints or floats to pass as a timeout 
+#   argument to calls made by the requests library. Defaults to None, i.e., no timeout.
+#   See requests docs for more info: http://docs.python-requests.org/en/master/user/advanced/
 ```
 Then use mc.execute(method='') to call the various methods (see documentation below) 
 

--- a/tests/tst_client.py
+++ b/tests/tst_client.py
@@ -18,8 +18,14 @@ def test_marketo_client(client):
     assert client.API_CALLS_MADE == 0
     assert client.API_LIMIT is None
 
-    client = MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20)
+    client = MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout=1.0)
     assert client.API_LIMIT == 20
+    assert client.requests_timeout == 1.0
+
+    invalid_requests_timeouts = ["a string", -1, (1,2,3), (1, -1), (1,"a string"), (1,)]
+    for invalid_requests_timeout in invalid_requests_timeouts:
+        with pytest.raises(AssertionError):
+            MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout=invalid_requests_timeout)
 
 
 @patch('marketorestpython.client.HttpLib')


### PR DESCRIPTION
This PR implements a new `requests_timeout` parameter when instantiating `MarketoClient`. This parameter is ultimately passed to all `requests.<method>` calls used in the `HttpLib` class. By default, `requests` does not implement any timeout functionality -- though they do recommend that "Nearly all production code should use this parameter in nearly all requests." ([source](https://docs.python-requests.org/en/latest/user/quickstart/#timeouts)). I have used this library in a production environment and seen some `requests.get` calls that hang for 30+ minutes at a time. The changes in this PR would enable users to customize this behavior.

The implementation involves setting the `requests_timeout` attribute on the `MarketoClient` class upon instantiation. The parameter may be a positive int, a positive float, or a two-tuple of positive ints/floats. These types are asserted on during instantiation.

This class attribute is then passed through the `HttpLib` class to all subsequent `requests` calls. The parameter defaults to `None`, to maintain existing implementations.

Please let me know if there's anything you'd like to see changed about this PR, or if you'd like to discuss it more, and thanks for the great work on this package!